### PR TITLE
Back-port of fix for globals in shell.

### DIFF
--- a/django/core/management/commands/shell.py
+++ b/django/core/management/commands/shell.py
@@ -13,8 +13,10 @@ class Command(NoArgsCommand):
 
     def ipython(self):
         try:
-            from IPython import embed
-            embed()
+            from IPython.frontend.terminal.ipapp import TerminalIPythonApp
+            app = TerminalIPythonApp.instance()
+            app.initialize(argv=[])
+            app.start()
         except ImportError:
             # IPython < 0.11
             # Explicitly pass an empty list as arguments, because otherwise


### PR DESCRIPTION
This is a back-port of the official Django 1.6 bug-fix for the shell. The bug comes from [shell.py](https://github.com/theatlantic/django/blob/atl/1.4.x/django/core/management/commands/shell.py#L16-17) initializing a slightly incorrect
version of IPython -- it starts an embed version rather than a terminal (`TerminalIPythonApp`). Functions declared in the embed don't inherit modifications to the global namespace (see below example).

The fix is short and direct (see link in notes). I tested this manually, and could not find any reports online of problems with this - so it should be safe.

Thoughts?
# Notes

Official fix released in Django 1.6:
https://github.com/django/django/commit/3570ff734e93f493e023b912c9a97101f605f7f5

A discussion and diagnosis of the problem with `embed` in IPython:
https://github.com/ipython/ipython/issues/62
# Example

Everyone has encountered the following problem:

```
In [1]: a = 1

In [2]: def f(x):
   ...:     return a*x
   ...:

In [3]: f(2)
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
/Volumes/www/workspace/Atlantic-CMS/src/django/django/core/management/commands/shell.py in <module>()
----> 1 f(2)

/Volumes/www/workspace/Atlantic-CMS/src/django/django/core/management/commands/shell.py in f(x)
      1 def f(x):
----> 2     return a*x
      3

NameError: global name 'a' is not defined
```
